### PR TITLE
rewritten gurobi call with explicit variable bounds

### DIFF
--- a/quadratic_functions/gurobi/test_linesearch_aligned.py
+++ b/quadratic_functions/gurobi/test_linesearch_aligned.py
@@ -37,7 +37,7 @@ def test_linesearch_aligned():
     Z = spa.csc_matrix((n, n))
     P = spa.csc_matrix([[mu, 0], [0, L]])
 
-    Hobj = .5 * spa.bmat([[Z, Z], [Z, P]], format='csc')  # not negative since we maximize
+    Hobj = -.5 * spa.bmat([[Z, Z], [Z, P]], format='csc')
     #  cobj = np.zeros(2 * n)
     #  dobj = 0
 
@@ -57,33 +57,19 @@ def test_linesearch_aligned():
                   name='y',
                   ub=gp.GRB.INFINITY * np.ones(2 * n),
                   lb=-gp.GRB.INFINITY * np.ones(2 * n))
-    m.setObjective(y @ Hobj @ y, GRB.MAXIMIZE)
+    m.setObjective(y @ Hobj @ y, GRB.MINIMIZE)
     m.addConstr(y @ Hineq @ y <= R ** 2)
     m.addConstr(y @ Heq1 @ y == 0)
     m.addConstr(y @ Heq2 @ y == 0)
+    m.addConstr(y @ Hobj @ y <= -.75)  # fake constraint to give gurobi an upper bound
 
-    # Trying with more declarative variables
-    #  Pblock = spa.bmat([[P, Z], [Z, P]], format='csc')
-    #  m = gp.Model()
-    #  m.setParam('NonConvex', 2)
-    #
-    #  x = m.addMVar(2 * n,
-    #                name='x',
-    #                ub=gp.GRB.INFINITY * np.ones(2 * n),
-    #                lb=-gp.GRB.INFINITY * np.ones(2 * n))
-    #  y = m.addMVar(2 * n,
-    #                name='y',
-    #                ub=gp.GRB.INFINITY * np.ones(2 * n),
-    #                lb=-gp.GRB.INFINITY * np.ones(2 * n))
-    #
-    #  m.setObjective(x @ Hobj @ x, GRB.MAXIMIZE)
-    #  m.addConstr(y == Pblock @ x)
-    #  m.addConstr(y[n:] @ x[n:] - y[n:] @ x[:n] <= 1e-03)
-    #  m.addConstr(y[n:] @ y[:n] <= 1e-03)
-    #  m.addConstr(x[:n] @ x[:n] <= R ** 2)
-    #
     m.optimize()
-    m.printAttr('y')
+    # import pdb
+    # pdb.set_trace()
+    y_grb = m.getVars()
+    y = np.array([y_grb[i].X for i in range(2 * n)])
+    print(y)
+    # m.printAttr('y')
 
 
 def main():


### PR DESCRIPTION
Gurobi default variables have bounds `[0, +inf)`. That's because of old-school simplex optimization mindset. If you set the right bounds, Gurobi tries to solve the nonconvex problem (and it takes ages). It finds an incumbent quickly with a value of `7.61` but it cannot find a reasonable upper bound (we are maximizing). What value does the SDP relaxation give for this example? 

Feel free to merge this whenever you like.